### PR TITLE
Periodic logs config option for novatel oem615 sim

### DIFF
--- a/sims/sim_common/cfg/nos3-simulator.xml
+++ b/sims/sim_common/cfg/nos3-simulator.xml
@@ -55,7 +55,15 @@
                     <port>4242</port>
                     <max-connection-attempts>5</max-connection-attempts>
                     <retry-wait-seconds>5</retry-wait-seconds>
-                </data-provider>               
+                </data-provider>
+                <log-messages>
+                    <log><message>BESTXYZA</message>
+                        <periodic>true</periodic>
+                    </log>
+                    <log><message>RANGECMPA</message>
+                        <periodic>true</periodic>
+                    </log>
+                </log-messages>               
                 <!-- <data-provider>               
                     <type>GPSFILE</type>
                     <filename>gps_data.42</filename>


### PR DESCRIPTION
By default, `nos3-simulator.xml` configures the Novatel oem6 sim to send periodic BESTXYZA and RANGECMPA log messages to the FSW, just as before. 
### Purpose: Configuration for Kubos fsw
Kubos doesn't support ASCII log messages.  These config options enable the sim to talk to Kubos correctly.
Set the ascii logs (i.e. BESTXYZ**A**)  `<periodic>false</periodic>`.
Optionally set binary logs (i.e. BESTXYZ**B**) `<periodic>true</periodic>`.

```
                <log-messages>
                    <log><message>BESTXYZA</message>
                        <periodic>false</periodic>
                    </log>
                    <log><message>RANGECMPA</message>
                        <periodic>false</periodic>
                    </log>
                    <log><message>BESTXYZB</message>
                        <periodic>true</periodic>
                    </log>
                    <log><message>RANGECMPB</message>
                        <periodic>true</periodic>
                    </log>
                </log-messages>   
```