### PR TITLE
Update Vagrantfile for VirtualBox 6.1 support.

### DIFF
--- a/support/Vagrantfile
+++ b/support/Vagrantfile
@@ -44,7 +44,11 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "../", "/vagrant_parent"
   # X11 Forwarding
   config.ssh.forward_x11 = true
-  
+
+  # Save off ruby variable with VirtualBox version number
+  vbox = VagrantPlugins::ProviderVirtualBox::Driver::Meta.new
+  vbox_version = vbox.version
+
   config.vm.provider "virtualbox" do |vb|
     if os == '1' 
       vb.name = "NOS3_CentOS"
@@ -66,12 +70,13 @@ Vagrant.configure(2) do |config|
     # Connect network
     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     # Clipboard
-	  vb.customize ["modifyvm", :id, '--clipboard', 'bidirectional']
+    if vbox_version.match(/^6.0/)
+      vb.customize ["modifyvm", :id, '--clipboard', 'bidirectional']
+    else
+      # --clipboard changed to --clipboard-mode in VirtualBox 6.1.
+      vb.customize ["modifyvm", :id, '--clipboard-mode', 'bidirectional']
+    end
   end
-
-  # Save off ruby variable with VirtualBox version number
-  vbox = VagrantPlugins::ProviderVirtualBox::Driver::Meta.new
-  vbox_version = vbox.version
 
   if os == '1'
     # CentOS


### PR DESCRIPTION
Conditionally using --clipboard-mode instead of --clipboard in 6.1.