### PR TITLE
126 nos time driver send ticks to multiple nos engine servers for distribution

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ Vagrant.configure("2") do |config|
         owner: 'root', group:'vboxsf', automount:'true', 
         mount_options: ["dmode=0770", "fmode=0770"]
 
+    config.vm.network "private_network", ip: "192.168.42.100"
+
     ### General configuration
     config.vm.provider "virtualbox" do |vbox|
         vbox.name = "nos3_1.6.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,6 @@ Vagrant.configure("2") do |config|
         owner: 'root', group:'vboxsf', automount:'true', 
         mount_options: ["dmode=0770", "fmode=0770"]
 
-    config.vm.network "private_network", ip: "192.168.42.100"
-
     ### General configuration
     config.vm.provider "virtualbox" do |vbox|
         vbox.name = "nos3_1.6.0"

--- a/gsw/scripts/launch.sh
+++ b/gsw/scripts/launch.sh
@@ -48,7 +48,7 @@ gnome-terminal --tab --title="42 Dynamic Simulator" -- /opt/nos3/42/42 NOS3InOut
 echo "Simulators..."
 cd $SIM_BIN
 gnome-terminal --tab --title="NOS Engine Server" -- /usr/bin/nos_engine_server_standalone -f $SIM_BIN/nos_engine_server_config.json
-gnome-terminal --tab --title="NOS Time Driver" -- $SIM_BIN/nos-time-driver
+#gnome-terminal --tab --title="NOS Time Driver" -- $SIM_BIN/nos3-single-simulator time
 gnome-terminal --tab --title="NOS Terminal" -- $SIM_BIN/nos3-simulator-terminal
 gnome-terminal --tab --title='CAM Sim' -- $SIM_BIN/nos3-cam-simulator
 gnome-terminal --tab --title='RW Sim' -- $SIM_BIN/nos3-generic-reactionwheel-simulator

--- a/sims/cfg/nos3-simulator.xml
+++ b/sims/cfg/nos3-simulator.xml
@@ -10,7 +10,7 @@
         <absolute-start-time>814048200.0</absolute-start-time>
         <sim-microseconds-per-tick>10000</sim-microseconds-per-tick>
 		<real-microseconds-per-tick>10000</real-microseconds-per-tick>
-        <nos-connection-string>tcp://127.0.0.1:12001</nos-connection-string>
+        <nos-connection-string>tcp://0.0.0.0:12001</nos-connection-string>
     </common>
 
     <simulators>
@@ -23,6 +23,7 @@
                 <connections>
                     <!-- <connection><type>command</type><bus-name>command</bus-name><node-name>time-command</node-name></connection> -->
                     <connection><type>time</type><bus-name>command</bus-name><node-name>time-driver</node-name></connection>
+                    <!-- <connection><type>time</type><nos-connection-string>tcp://192.168.1.197:12001</nos-connection-string><bus-name>command</bus-name><node-name>time-driver</node-name></connection> -->
                 </connections>
             </hardware-model>
         </simulator>

--- a/sims/cfg/nos3-simulator.xml
+++ b/sims/cfg/nos3-simulator.xml
@@ -23,7 +23,7 @@
                 <connections>
                     <!-- <connection><type>command</type><bus-name>command</bus-name><node-name>time-command</node-name></connection> -->
                     <connection><type>time</type><bus-name>command</bus-name><node-name>time-driver</node-name></connection>
-                    <!-- <connection><type>time</type><nos-connection-string>tcp://192.168.1.197:12001</nos-connection-string><bus-name>command</bus-name><node-name>time-driver</node-name></connection> -->
+                    <!-- <connection><type>time</type><nos-connection-string-override>tcp://192.168.42.101:12001</nos-connection-string-override><bus-name>command</bus-name><node-name>time-driver</node-name></connection> -->
                 </connections>
             </hardware-model>
         </simulator>

--- a/sims/cfg/nos_engine_server_config.json
+++ b/sims/cfg/nos_engine_server_config.json
@@ -6,11 +6,11 @@
     "server_uris": [
         {
             "name": "fsw",
-            "server_uri": "tcp://127.0.0.1:12000"
+            "server_uri": "tcp://0.0.0.0:12000"
         },
         {
             "name": "nos3",
-            "server_uri": "tcp://127.0.0.1:12001"
+            "server_uri": "tcp://0.0.0.0:12001"
         }
     ]
 }


### PR DESCRIPTION
Can be merged once the following submodule merges are completed:
 
- [x] https://github.com/nasa-itc/nos_time_driver/pull/1

Closes https://github.com/nasa/nos3/issues/126

