### PR TITLE
[nasa/nos3#205] Updated sample checkout

### DIFF
--- a/gsw/scripts/checkout.sh
+++ b/gsw/scripts/checkout.sh
@@ -12,11 +12,11 @@ SIMS=$(cd $SIM_BIN; ls nos3*simulator)
 
 echo "Simulators..."
 cd $SIM_BIN
-gnome-terminal --tab --title="NOS Engine Server" -- /usr/bin/nos_engine_server_standalone -f $SIM_BIN/nos_engine_server_config.json
-gnome-terminal --tab --title="NOS Time Driver" -- $SIM_BIN/nos3-single-simulator time
-gnome-terminal --tab --title="NOS Terminal" -- $SIM_BIN/nos3-single-simulator terminal
+gnome-terminal --tab --title="NOS Engine Server"  -- /usr/bin/nos_engine_server_standalone -f $SIM_BIN/nos_engine_server_config.json
+gnome-terminal --tab --title="NOS Time Driver"    -- $SIM_BIN/nos3-single-simulator time
+gnome-terminal --tab --title="NOS STDIO Terminal" -- $SIM_BIN/nos3-single-simulator stdio-terminal
 
 # Rename for your simulator under test to allow checkout
-gnome-terminal --tab --title='Sample Sim' -- $SIM_BIN/nos3-sample-simulator
+gnome-terminal --tab --title='Sample Sim'         -- $SIM_BIN/nos3-single-simulator sample_sim
 
 # It is assumed you'll build and launch the checkout manually

--- a/gsw/scripts/fsw_respawn.sh
+++ b/gsw/scripts/fsw_respawn.sh
@@ -12,7 +12,12 @@ do
     pidof core-cpu1 > /dev/null
     if [ $? -eq 1 ]
     then
-        gnome-terminal --title="NOS3 Flight Software" -- $FSW_BIN/core-cpu1 -R PO
+        sleep 5
+        pidof core-cpu1 > /dev/null
+        if [ $? -eq 1 ]
+        then
+            gnome-terminal --title="NOS3 Flight Software" -- $FSW_BIN/core-cpu1 -R PO
+        fi
     fi
     sleep 1
 done


### PR DESCRIPTION
https://github.com/nasa-itc/sample/pull/10

Can test by:
- git checkout nos3#205-SampleCheckout
- make clean
- git submodule update --init --recursive 
- make
- make checkout
  -  At this point tabs should open for NOS Engine Server, NOS Time Driver, NOS STDIO Terminal, and Sample Sim
- Leave these open for now
- In a new terminal window, called the checkout terminal in the future
  - cd nos3/components/sample/support
  - mkdir build
  - cd build
  - cmake .. -DTGTNAME=cpu1
  - make
  - ./sample_checkout
- In the `NOS STDIO Terminal`
  - transact 120 enable
    - A confirmation should be provided: “SampleHardwareModel::command_callback:  Enabled”
- In the checkout terminal
  - You should be able to send commands and get responses successfully
