### PR TITLE
https://github.com/nasa/nos3/issues/357 - Remove deletion of gsw/cosm…

### DIFF
--- a/scripts/docker_stop.sh
+++ b/scripts/docker_stop.sh
@@ -34,6 +34,5 @@ rm -rf /tmp/gpio*
 # COSMOS
 yes | rm $GSW_DIR/Gemfile > /dev/null 2>&1
 yes | rm $GSW_DIR/Gemfile.lock > /dev/null 2>&1
-yes | rm -r $GSW_DIR/COMPONENTS > /dev/null 2>&1
 
 exit 0


### PR DESCRIPTION
…os/COMPONENTS directory from the stop script so that make gsw does not need run between make stop and make launch commands.

Closes #357 