### PR TITLE
nos3#384 producing data on a schedule

### DIFF
--- a/cfg/sims/nos3-simulator.xml
+++ b/cfg/sims/nos3-simulator.xml
@@ -623,8 +623,8 @@
                         <node-name>star-tracker-command</node-name>
                     </connection>
                     <connection><type>usart</type>
-                        <bus-name>usart_29</bus-name>
-                        <node-port>29</node-port>
+                        <bus-name>usart_10</bus-name>
+                        <node-port>10</node-port>
                     </connection>
                 </connections>
                 <data-provider>


### PR DESCRIPTION
Fprime can send request HK data at 1 hz (currently set to 20 times, rather than indefinitely).

Steps to replicate:
1. pull nos3#384, submodule update
2. change nos3 config to fprime and fprime for gsw and fsw.
3. build and launch
4. In fprime-gds, send the sample_seq command, verify request hk comes down at 1 hz. You should see it stop after 20 commands

Note, sequence cancelling is Work in Progress. There was a bug with seq_cancel command. 

Also, included start tracker uart number change back to 10. So, Also verify star tracker works with cfs and cosmos.

Will need to merge 384 branches into dev branches for fprime and high level nos3