### PR TITLE
[nasa/nos3#463] Generic CSS Checkout

### DIFF
--- a/scripts/cfg/configure.py
+++ b/scripts/cfg/configure.py
@@ -469,11 +469,11 @@ else:
 
         sim_disabled = '            <active>false</active>\n'
         if (sc_cam_en != 'true'):
-            lines[css_index] = sim_disabled
+            lines[cam_index] = sim_disabled
         if (sc_css_en != 'true'):
             lines[css_index] = sim_disabled
         if (sc_eps_en != 'true'):
-            lines[css_index] = sim_disabled
+            lines[eps_index] = sim_disabled
         if (sc_fss_en != 'true'):
             lines[fss_index] = sim_disabled
         if (sc_gps_en != 'true'):
@@ -483,7 +483,7 @@ else:
         if (sc_mag_en != 'true'):
             lines[mag_index] = sim_disabled
         if (sc_radio_en != 'true'):
-            lines[mag_index] = sim_disabled
+            lines[radio_index] = sim_disabled
         if (sc_rw_en != 'true'):
             lines[rw0_index] = sim_disabled
             lines[rw1_index] = sim_disabled

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -64,9 +64,20 @@ echo "Checkout..."
 #gnome-terminal --tab --title="Arducam Sim"   -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_cam_sim"   --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE camsim
 #gnome-terminal --title="Arducam Checkout"   -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_arducam_checkout"   --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/arducam/fsw/standalone/build/arducam_checkout
 
-# ##
-# ## Fine Sun Sensor (FSS)
-# ##
+##
+## Coarse Sun Sensor (CSS)
+##
+# rm -rf $USER_NOS3_DIR/42/NOS3InOut
+# cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
+# xhost +local:*
+# gnome-terminal --tab --title=$SC_NUM" - 42" -- $DFLAGS -e DISPLAY=$DISPLAY -v $USER_NOS3_DIR:$USER_NOS3_DIR -v /tmp/.X11-unix:/tmp/.X11-unix:ro --name $SC_NUM"_fortytwo" -h fortytwo --network=$SC_NETNAME -w $USER_NOS3_DIR/42 -t $DBOX $USER_NOS3_DIR/42/42 NOS3InOut
+# echo ""
+# gnome-terminal --tab --title=$SC_NUM" - CSS Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_css_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_css_sim
+# gnome-terminal --title="CSS Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_css_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_css/fsw/standalone/build/generic_css_checkout
+
+##
+## Fine Sun Sensor (FSS)
+##
 # rm -rf $USER_NOS3_DIR/42/NOS3InOut
 # cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
 # xhost +local:*


### PR DESCRIPTION
Added a checkout application for the generic_css component. Have verified the checkout launches and can be commanded in the newest push. The branch is set up so that the top level files should be set up as normal in dev, and thus need to be modified to work the checkout. The old checkout used the wrong organization, and was a clone of sample with renames and not actually operational. The new one is set up with the new format, utilizes I2C like the CSS device, and operates for the data request.

Steps:

Enable CSS in the NOS3 minimal config, and uncomment the Coarse Sun Sensor (CSS) part of checkout.sh in scripts.

`make clean`
`make debug`
`cd components/generic_css/fsw/standalone/build`
(`mkdir build` in the standalone directory if needed, then `cd build`)
`make clean` (if build directory already exists)
`cmake .. -DTGTNAME=cpu1`
`make`
`exit`
`make clean`
`make`
`make checkout`

The following submodule PRs must be merged and updated first:

https://github.com/nasa-itc/generic_css/pull/9

Closes https://github.com/nasa/nos3/issues/463