### PR TITLE
[nasa/nos3#443] Update Uninstall Scripting

### DIFF
--- a/scripts/cfg/uninstall.sh
+++ b/scripts/cfg/uninstall.sh
@@ -6,7 +6,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../env.sh
 
-echo "Cleaning up all COSMOS files..."
+echo "Cleaning up any COSMOS files..."
 yes | rm $BASE_DIR/gsw/cosmos/Gemfile 2> /dev/null
 yes | rm $BASE_DIR/gsw/cosmos/Gemfile.lock 2> /dev/null
 yes | rm -r $BASE_DIR/gsw/cosmos/COMPONENTS 2> /dev/null
@@ -15,22 +15,19 @@ yes | rm -r $BASE_DIR/gsw/cosmos/outputs 2> /dev/null
 echo "Cleaning up Minicom log..."
 yes | rm $BASE_DIR/minicom.cap 2> /dev/null
 
-echo "Cleaning up CryptoLib build..."
-yes | rm $BASE_DIR/minicom.cap 2> /dev/null
-
 echo "Cleaning up local user directory..."
-$DFLAGS -v $USER_NOS3_DIR:$USER_NOS3_DIR $DBOX rm -rf $USER_NOS3_DIR
+if docker ps -a --format "{{.Names}}" | grep -q "^${DBOX}$"; then
+    rm -f "${USER_NOS3_DIR}"
+fi
 rm -rf $USER_NOS3_DIR/*
 rm -rf $USER_FPRIME_PATH
 
-yes | rm -rf $USER_NOS3_DIR/.m2 2> /dev/null
-yes | rm -rf $USER_NOS3_DIR 2> /dev/null
+echo "Removing NOS Based containers..."
+yes 2> /dev/null | $DCALL images --format "{{.Repository}}:{{.Tag}}" | grep '^ivvitc' | xargs -r docker rmi  
 
-echo "Removing containers..."
-$DCALL system prune -f 2> /dev/null
+echo "Removing NOS Based container networks..."
+yes | $DNETWORK ls --format "{{.Name}}" | grep '^nos3_' | xargs -r docker network rm 2> /dev/null
 
-echo "Removing container networks..."
-yes | docker network prune -f 2> /dev/null
-yes | docker swarm leave --force 2> /dev/null
+yes | $DCALL swarm leave --force 2> /dev/null
 
 exit 0


### PR DESCRIPTION
Updated the installation script.

Will now only remove ivvitc based containers
Properly cleans up hidden .nos3 directories - with corner casing if container doesn't exist, so it doesn't download again.
Cleaned up container network removal to only remove nos3 based networks 
Cleaned up unnecessary rm commands that are completed elsewhere.