### PR TITLE
[nasa/nos3#462] arducam checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build
 support/nos3_install.log
 tmp
 core.*
+exp.jpg
 
 #
 # Misc

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ build
 support/nos3_install.log
 tmp
 core.*
-exp.jpg
+pic.jpg
+cam.jpg
 
 #
 # Misc

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -61,8 +61,8 @@ echo "Checkout..."
 ##
 ## Arducam
 ##
-#gnome-terminal --tab --title="Arducam Sim"   -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_cam_sim"   --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE camsim
-#gnome-terminal --title="Arducam Checkout"   -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_arducam_checkout"   --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/arducam/fsw/standalone/build/arducam_checkout
+# gnome-terminal --tab --title="Arducam Sim"   -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_cam_sim"   --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE camsim
+# gnome-terminal --title="Arducam Checkout"   -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_arducam_checkout"   --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/arducam/fsw/standalone/build/arducam_checkout
 
 ##
 ## Coarse Sun Sensor (CSS)


### PR DESCRIPTION
Finished updating the Arducam checkout to allow it to take pictures, as that logic was previously incomplete. For this, I modified the device and some config code slightly to make the output location consistent with our current VM and to allow the generation of an actual picture to be toggled on by default in the checkout and off by default (current state in dev) for when cFS is running. Then I replicated the logic from parts of the child task in the partially complete logic for taking pictures in checkout, to allow the reading of the data.

Steps:

Enable Arducam in the NOS3 minimal config, switch to using the minimal config in the top level no3 mission config, and uncomment the Arducam part of checkout.sh in scripts.

`make clean`
`make debug`
`cd components/arducam/fsw/standalone/build`
(`mkdir build` in the standalone directory if needed, then `cd build`)
`make clean` (if build directory already exists)
`cmake .. -DTGTNAME=cpu1`
`make`
`exit`
`make clean`
`make`
`make checkout`

Run the commands and check the picture generated (should be called pic.jpg) and verify it is a picture of someone holding the STF-1 Patch when the picture read is complete. Can also delete the picture file and run with FSW to prove that the picture is not being generated when running FSW due to the new switch in platform_cfg for generating the picture.

The following submodule PRs must be merged and updated first:

https://github.com/nasa-itc/arducam/pull/8

Closes #462 

