### PR TITLE
[nasa/nos3#468] thruster checkout

### DIFF
--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -119,12 +119,22 @@ echo "Checkout..."
 #gnome-terminal --tab --title=$SC_NUM" - RW 2 Sim"     -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_rw_sim2"      --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic-reactionwheel-sim2
 #gnome-terminal --title="RW Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_rw_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_reaction_wheel/fsw/standalone/build/generic_reaction_wheel_checkout
 
-
 ##
 ## Sample
 ##
 # gnome-terminal --tab --title="Sample Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_sample_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE sample_sim
 # gnome-terminal --title="Sample Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_sample_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/sample/fsw/standalone/build/sample_checkout
+
+##
+## Thruster
+##
+# rm -rf $USER_NOS3_DIR/42/NOS3InOut
+# cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
+# xhost +local:*
+# gnome-terminal --tab --title=$SC_NUM" - 42" -- $DFLAGS -e DISPLAY=$DISPLAY -v $USER_NOS3_DIR:$USER_NOS3_DIR -v /tmp/.X11-unix:/tmp/.X11-unix:ro --name $SC_NUM"_fortytwo" -h fortytwo --network=$SC_NETNAME -w $USER_NOS3_DIR/42 -t $DBOX $USER_NOS3_DIR/42/42 NOS3InOut
+# echo ""
+# gnome-terminal --tab --title=$SC_NUM" - Thruster Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_thruster_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_thruster_sim
+# gnome-terminal --title="Thruster Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_thruster_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_thruster/fsw/standalone/build/generic_thruster_checkout
 
 ##
 ## Torquer

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -128,13 +128,13 @@ echo "Checkout..."
 ##
 ## Thruster
 ##
-# rm -rf $USER_NOS3_DIR/42/NOS3InOut
-# cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
-# xhost +local:*
-# gnome-terminal --tab --title=$SC_NUM" - 42" -- $DFLAGS -e DISPLAY=$DISPLAY -v $USER_NOS3_DIR:$USER_NOS3_DIR -v /tmp/.X11-unix:/tmp/.X11-unix:ro --name $SC_NUM"_fortytwo" -h fortytwo --network=$SC_NETNAME -w $USER_NOS3_DIR/42 -t $DBOX $USER_NOS3_DIR/42/42 NOS3InOut
-# echo ""
-# gnome-terminal --tab --title=$SC_NUM" - Thruster Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_thruster_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_thruster_sim
-# gnome-terminal --title="Thruster Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_thruster_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_thruster/fsw/standalone/build/generic_thruster_checkout
+#rm -rf $USER_NOS3_DIR/42/NOS3InOut
+#cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
+#xhost +local:*
+#gnome-terminal --tab --title=$SC_NUM" - 42" -- $DFLAGS -e DISPLAY=$DISPLAY -v $USER_NOS3_DIR:$USER_NOS3_DIR -v /tmp/.X11-unix:/tmp/.X11-unix:ro --name $SC_NUM"_fortytwo" -h fortytwo --network=$SC_NETNAME -w $USER_NOS3_DIR/42 -t $DBOX $USER_NOS3_DIR/42/42 NOS3InOut
+#echo ""
+#gnome-terminal --tab --title=$SC_NUM" - Thruster Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_thruster_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_thruster_sim
+#gnome-terminal --title="Thruster Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_thruster_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_thruster/fsw/standalone/build/generic_thruster_checkout
 
 ##
 ## Torquer


### PR DESCRIPTION
Added a checkout application for the generic_thruster component. Have verified the checkout launches and can be commanded in the newest push. The branch is set up so that the top level files should be set up as normal in dev, and thus need to be modified to work the checkout. There was a previous checkout using support, but it was identical to old sample, so I started from scratch. There was also no device.c or device.h, and that functionality was done in the app. I have modified the app to utilize a method in device to access UART, and have set up the device files, with only what code is necessary (I believe). I have tested operation both with YAMCS and the rest of FSW, and with the checkout to ensure it all works, and would encourage others to do the same when testing this.

The only concern I still see:

The sim is slow to connect to 42. Wait, and it eventually will, after spamming out errors failing to connect for a while. I am not sure why it is so slow to connect. May be worth further investigation, but for now, just wait for it to connect before commanding.

Steps:

Enable Thruster in the NOS3 minimal config, switch to using the minimal config in the top level no3 mission config, and uncomment the Thruster part of checkout.sh in scripts.

`make clean`
`make debug`
`cd components/generic_thruster/fsw/standalone/build`
(`mkdir build` in the standalone directory if needed, then `cd build`)
`make clean` (if build directory already exists)
`cmake .. -DTGTNAME=cpu1`
`make`
`exit`
`make clean`
`make`
`make checkout`

The following submodule PRs must be merged and updated first:

https://github.com/nasa-itc/generic_thruster/pull/2

Closes #468 