### PR TITLE
[nasa/nos3#498] Vagrant Disk Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Build from the docs/wiki directory:  `make html`
 ### Prerequisites
 Each of the applications listed below are required prior to performing the installation procedure:
 * Option A, you already use Linux
-  * [Git 2.36+](https://git-scm.com/)
+  * [Git 2.47+](https://git-scm.com/)
   * Linux with docker and docker compose installed
 * Option B, deployment of a virtual machine (VM)
-  * [Git 2.36+](https://git-scm.com/)
-  * [Vagrant 2.3.4+](https://www.vagrantup.com/)
-  * [VirtualBox 7.0+](https://www.virtualbox.org/)
+  * [Git 2.47+](https://git-scm.com/)
+  * [Vagrant 2.4.3+](https://www.vagrantup.com/)
+  * [VirtualBox 7.1.6+](https://www.virtualbox.org/)
 
 ### Installing
 Option B only.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure("2") do |config|
         mount_options: ["dmode=0770", "fmode=0770"]
 
     ### General configuration
+    config.vm.disk :disk, size: "64GB", primary: true
     config.vm.provider "virtualbox" do |vbox|
         vbox.name = "nos3_20231101"
         vbox.gui = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,4 +28,7 @@ Vagrant.configure("2") do |config|
         vbox.cpus = 4
         vbox.memory = "8192"
     end
+
+    ### Extend the partition to use all available space
+    config.vm.provision "shell", inline: "growpart /dev/sda 3 && lvextend -l +100%FREE -r /dev/mapper/ubuntu--vg-ubuntu--lv"
 end

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -105,4 +105,8 @@ According to the [NASA Software Classification guidelines](https://nodis3.gsfc.n
     - NASA's cFS is safety-critical flight software. Make sure you are building your applications to specification and that you are properly using the PSP and OSAL calls from within your apps.
     - It is best to **_not_** run cFS as sudo. If you are doing this, make sure you have configured for your host or are providing appropriate run-time arguments with cFS.
 6. Can NOS3 be run across multiple computers?
-    - Yes - the satellite and ground software can be split apart and run on their own VMs. The instructions can be found [here](https://github.com/nasa/nos3/wiki/NOS3-Build-and-Run-on-Multiple-VMs).
+    - Yes, the satellite and ground software can be split apart and run on their own VMs. The instructions can be found [here](https://github.com/nasa/nos3/wiki/NOS3-Build-and-Run-on-Multiple-VMs).
+7. Can the disk space be resized in the provided Virtual Machine?
+    - Yes, the Vagrantfile can be edited to change the maximum size of a new VM pending some additional terminal commands are done as sudo
+    - `growpart /dev/sda 3`
+    - `lvextend -l +100%FREE -r /dev/mapper/ubuntu--vg-ubuntu--lv`


### PR DESCRIPTION
Added line to Vagrantfile to allow extending the size of the VM disk.
Note some additional commands are required and were captured in the FAQ of the `./docs/wiki/Home.md`.

Closes #498

Notes on how this was tested prior to merge request are captured in the issue.