### PR TITLE
Nos3#522 generic torquer f

### DIFF
--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -4,11 +4,11 @@
 
     <!-- Ground Software -->
     <!-- cosmos, openc3, fprime, or yamcs (default) -->
-    <gsw>yamcs</gsw>
+    <gsw>fprime</gsw>
 
     <!-- Flight Software -->
     <!-- cfs (default) or fprime -->
-    <fsw>cfs</fsw>
+    <fsw>fprime</fsw>
 
     <!-- Number of spacecraft -->
     <!-- Note this is experimental and not ready for use beyond proof of concept -->
@@ -16,7 +16,7 @@
 
     <!-- Spacecraft 1 Configuration -->
     <!-- sc-full-config.xml (default), sc-minimal-config.xml, or sc-fprime-config.xml -->
-    <sc-1-cfg>sc-full-config.xml</sc-1-cfg>
+    <sc-1-cfg>sc-minimal-config.xml</sc-1-cfg>
 
     <!-- Spacecraft N Configuration -->
     <!-- <sc-N-cfg>sc-minimal-config.xml</sc-N-cfg> -->

--- a/cfg/sc-minimal-config.xml
+++ b/cfg/sc-minimal-config.xml
@@ -64,7 +64,7 @@
             <enable>false</enable>
         </syn>
         <torquer>
-            <enable>false</enable>
+            <enable>true</enable>
         </torquer>
         <thruster>
             <enable>false</enable>

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -180,10 +180,13 @@ echo "Checkout..."
 ##
 ## Torquer
 ##
-#gnome-terminal --tab --title=$SC_NUM" - Torquer Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
-#gnome-terminal --title="Torquer Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_torquer_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_torquer/fsw/standalone/build/generic_torquer_checkout
-
-
+rm -rf $USER_NOS3_DIR/42/NOS3InOut
+ cp -r $BASE_DIR/cfg/build/InOut $USER_NOS3_DIR/42/NOS3InOut
+ xhost +local:*
+ gnome-terminal --tab --title=$SC_NUM" - 42" -- $DFLAGS -e DISPLAY=$DISPLAY -v $USER_NOS3_DIR:$USER_NOS3_DIR -v /tmp/.X11-unix:/tmp/.X11-unix:ro --name $SC_NUM"_fortytwo" -h fortytwo --network=$SC_NETNAME -w $USER_NOS3_DIR/42 -t $DBOX $USER_NOS3_DIR/42/42 NOS3InOut
+ echo ""
+ gnome-terminal --tab --title=$SC_NUM" - Torquer Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim" -h trq_sim --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
+ gnome-terminal --title="Torquer Checkout" -- $DFLAGS -v $BASE_DIR:$BASE_DIR --name $SC_NUM"_torquer_checkout" --network=$SC_NETNAME -w $BASE_DIR $DBOX ./components/generic_torquer/fsw/standalone/build/generic_torquer_checkout
 # sleep 1
 # urlIP=$(docker container inspect sc_1_sample_checkout | grep -i IPAddress | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")
 # sleep 10

--- a/scripts/fsw/fsw_cfs_launch.sh
+++ b/scripts/fsw/fsw_cfs_launch.sh
@@ -132,7 +132,7 @@ do
     gnome-terminal --tab --title=$SC_NUM" - Sample Sim"   -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_sample_sim"   --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE sample_sim
     gnome-terminal --tab --title=$SC_NUM" - StarTrk Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_startrk_sim"  --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_star_tracker_sim
     gnome-terminal --tab --title=$SC_NUM" - Thruster Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_thruster_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_thruster_sim
-    gnome-terminal --tab --title=$SC_NUM" - Torquer Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim"  --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
+    gnome-terminal --tab --title=$SC_NUM" - Torquer Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim"  -h trq_sim --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
     echo ""
 done
 

--- a/scripts/fsw/fsw_fprime_launch.sh
+++ b/scripts/fsw/fsw_fprime_launch.sh
@@ -128,7 +128,7 @@ do
     gnome-terminal --tab --title=$SC_NUM" - Sample Sim"   -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_sample_sim"   --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE sample_sim
     gnome-terminal --tab --title=$SC_NUM" - StarTrk Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_startrk_sim"  --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_star_tracker_sim
     gnome-terminal --tab --title=$SC_NUM" - Thruster Sim" -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_thruster_sim" --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_thruster_sim
-    gnome-terminal --tab --title=$SC_NUM" - Torquer Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim"  --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
+    gnome-terminal --tab --title=$SC_NUM" - Torquer Sim"  -- $DFLAGS -v $SIM_DIR:$SIM_DIR --name $SC_NUM"_torquer_sim"  -h trq_sim --network=$SC_NETNAME -w $SIM_BIN $DBOX ./nos3-single-simulator $SC_CFG_FILE generic_torquer_sim
     echo ""
 done
 


### PR DESCRIPTION
This is the integration of the generic_torquer component into F' you should be able to see the percent and directions numbers result in the channels tab after sending a config command to set the numbers. Verify that the rest of nos3 runs as usual.

Pull nos3#522-generic-torquer-f
Test F'

convert the gsw and fsw to fprime
Test that Torquer_CONFIG works with Generic_torquer

This merge closes issue https://github.com/nasa/nos3/issues/522