### PR TITLE
[nasa/nos3#532] Reaction Wheel FPrime Integration

### DIFF
--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -4,11 +4,11 @@
 
     <!-- Ground Software -->
     <!-- cosmos, openc3, fprime, or yamcs (default) -->
-    <gsw>yamcs</gsw>
+    <gsw>fprime</gsw>
 
     <!-- Flight Software -->
     <!-- cfs (default) or fprime -->
-    <fsw>cfs</fsw>
+    <fsw>fprime</fsw>
 
     <!-- Number of spacecraft -->
     <!-- Note this is experimental and not ready for use beyond proof of concept -->
@@ -16,7 +16,7 @@
 
     <!-- Spacecraft 1 Configuration -->
     <!-- sc-full-config.xml (default), sc-minimal-config.xml, or sc-fprime-config.xml -->
-    <sc-1-cfg>sc-full-config.xml</sc-1-cfg>
+    <sc-1-cfg>sc-fprime-config.xml</sc-1-cfg>
 
     <!-- Spacecraft N Configuration -->
     <!-- <sc-N-cfg>sc-minimal-config.xml</sc-N-cfg> -->

--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -4,11 +4,11 @@
 
     <!-- Ground Software -->
     <!-- cosmos, openc3, fprime, or yamcs (default) -->
-    <gsw>fprime</gsw>
+    <gsw>yamcs</gsw>
 
     <!-- Flight Software -->
     <!-- cfs (default) or fprime -->
-    <fsw>fprime</fsw>
+    <fsw>cfs</fsw>
 
     <!-- Number of spacecraft -->
     <!-- Note this is experimental and not ready for use beyond proof of concept -->
@@ -16,7 +16,7 @@
 
     <!-- Spacecraft 1 Configuration -->
     <!-- sc-full-config.xml (default), sc-minimal-config.xml, or sc-fprime-config.xml -->
-    <sc-1-cfg>sc-fprime-config.xml</sc-1-cfg>
+    <sc-1-cfg>sc-full-config.xml</sc-1-cfg>
 
     <!-- Spacecraft N Configuration -->
     <!-- <sc-N-cfg>sc-minimal-config.xml</sc-N-cfg> -->

--- a/cfg/sc-fprime-config.xml
+++ b/cfg/sc-fprime-config.xml
@@ -52,7 +52,7 @@
             <enable>true</enable>
         </radio>
         <rw>
-            <enable>false</enable>
+            <enable>true</enable>
         </rw>
         <sample>
             <enable>true</enable>


### PR DESCRIPTION
Integrated the checkout for Reaction Wheels into F', and verified operations of the get_momentum and set_torque commands.

This can be tested by loading up NOS3 in the correct branch, running find . `-type f -print0 | xargs -0 dos2unix` in the top level to assure all your bash files and configured for unix systems (if in shared folders and your git bash is setup to pull as windows; _you will likely need to do a repo rinse after this_), modifying the top level nos3 config to use fprime for gsw and fsw and to use the nos3_fprime_cfg for its spacecraft config, then save, `make clean`, `make`, and `make launch`. Then, test running the RW set torque and get momentum commands, and assure they show up on the sim, that they are marked as successful in the events tab of the GSW, and that the values come through in channels. You can also check that the values are consistent with the ones being spit out by the sim, and that any momentum is consistent with the torque you applied.

Required Submodule Merges:
https://github.com/nasa-itc/fprime-nos3/pull/9
https://github.com/nasa-itc/generic_reaction_wheel/pull/10

Closes #532 