### PR TITLE
[nasa/nos3#561] Configuration as part of Make Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ env:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
     fsw:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ GSWBUILDDIR ?= $(CURDIR)/gsw/build
 SIMBUILDDIR ?= $(CURDIR)/sims/build
 COVERAGEDIR ?= $(CURDIR)/fsw/build/amd64-posix/default_cpu1
 
+SC1_CFG ?= 
+
 export SYSTEM_TEST_FILE_PATH = /scripts/gsw/system_test.rb
 
 export CFS_APP_PATH = ../components
@@ -113,8 +115,14 @@ clean-gsw:
 	rm -rf gsw/cosmos/build
 	rm -rf /tmp/nos3
 
+
 config:
-	./scripts/cfg/config.sh
+	@if [ -n "$(SC1_CFG)" ]; then \
+		echo "Overriding sc-1-cfg with: $(SC1_CFG)"; \
+		SC1_CFG="$(SC1_CFG)" ./scripts/cfg/config.sh; \
+	else \
+		./scripts/cfg/config.sh; \
+	fi
 
 debug:
 	./scripts/debug.sh
@@ -160,6 +168,17 @@ start-sat:
 
 stop:
 	./scripts/stop.sh
+	@if [ -f ./cfg/build/current_config_path.txt ]; then \
+	  echo "Cleaning up temporary config file..."; \
+	  CONFIG_FILE=$$(cat ./cfg/build/current_config_path.txt | tr -d '\n'); \
+	  if [ "$$(basename $$CONFIG_FILE)" != "nos3-mission.xml" ]; then \
+	    echo "Removing $$CONFIG_FILE"; \
+	    rm -f "$$CONFIG_FILE"; \
+	  fi; \
+	  rm -f ./cfg/build/current_config_path.txt; \
+	fi
+
+
 
 stop-gsw:
 	./scripts/gsw/stop_gsw.sh

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,16 @@ OTHERTGTS := $(filter-out $(LOCALTGTS),$(MAKECMDGOALS))
 # Commands
 #
 all:
-	$(MAKE) config
+	@if [ ! -f ./cfg/build/current_config_path.txt ]; then \
+		echo "Running make config (initial)..."; \
+		$(MAKE) config; \
+	else \
+		echo "Skipping make config (already configured)"; \
+	fi
 	$(MAKE) fsw
 	$(MAKE) sim
 	$(MAKE) gsw
+
 
 build-cryptolib:
 	mkdir -p $(GSWBUILDDIR)
@@ -118,7 +124,6 @@ clean-gsw:
 
 config:
 	@if [ -n "$(SC1_CFG)" ]; then \
-		echo "Overriding sc-1-cfg with: $(SC1_CFG)"; \
 		SC1_CFG="$(SC1_CFG)" ./scripts/cfg/config.sh; \
 	else \
 		./scripts/cfg/config.sh; \

--- a/scripts/cfg/config.sh
+++ b/scripts/cfg/config.sh
@@ -9,7 +9,8 @@ ORIGINAL_CONFIG="$BASE_DIR/cfg/nos3-mission.xml"
 CONFIG_FILE="$ORIGINAL_CONFIG"
 
 # Make flight software configuration directory
-mkdir -p "$BASE_DIR/cfg/build"
+mkdir -p "$BASE_DIR/cfg/build/temp_mission/"
+cp -r "$BASE_DIR/cfg/nos3-mission.xml" "$BASE_DIR/cfg/build/temp_mission/"
 
 # Copy baseline configurations into build directory
 cp -r "$BASE_DIR/cfg/InOut" "$BASE_DIR/cfg/build/"
@@ -27,7 +28,7 @@ if [ -n "${SC1_CFG// }" ]; then
     fi
 
     echo "Overriding <sc-1-cfg> with: $REL_SC1_CFG"
-    TEMP_CONFIG=$(mktemp "$BASE_DIR/cfg/XXXXXX.xml")
+    TEMP_CONFIG=$(mktemp "$BASE_DIR/cfg/build/temp_mission/XXXXXX.xml")
     sed "s|<sc-1-cfg>.*</sc-1-cfg>|<sc-1-cfg>$REL_SC1_CFG</sc-1-cfg>|" "$ORIGINAL_CONFIG" > "$TEMP_CONFIG"
     CONFIG_FILE="$TEMP_CONFIG"
 

--- a/scripts/cfg/config.sh
+++ b/scripts/cfg/config.sh
@@ -1,18 +1,42 @@
 #!/bin/bash -i
-#
+
 # Convenience script for NOS3 development
-#
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source $SCRIPT_DIR/../env.sh
+source "$SCRIPT_DIR/../env.sh"
+
+ORIGINAL_CONFIG="$BASE_DIR/cfg/nos3-mission.xml"
+CONFIG_FILE="$ORIGINAL_CONFIG"
+
+# If SC1_CFG is passed in, validate and patch
+if [ -n "${SC1_CFG// }" ]; then
+    REL_SC1_CFG="${SC1_CFG#cfg/}"   # Strip leading cfg/ if present
+    FULL_SC1_CFG="$BASE_DIR/cfg/$REL_SC1_CFG"
+
+    if [ ! -f "$FULL_SC1_CFG" ]; then
+        echo "ERROR: Config file '$FULL_SC1_CFG' does not exist."
+        exit 1
+    fi
+
+    echo "Overriding <sc-1-cfg> with: $REL_SC1_CFG"
+    TEMP_CONFIG=$(mktemp)
+    sed "s|<sc-1-cfg>.*</sc-1-cfg>|<sc-1-cfg>$REL_SC1_CFG</sc-1-cfg>|" "$ORIGINAL_CONFIG" > "$TEMP_CONFIG"
+    CONFIG_FILE="$TEMP_CONFIG"
+
+    echo "$CONFIG_FILE" > "$BASE_DIR/cfg/build/current_config_path.txt"
+else
+    echo "NO CHANGES TO CONFIG"
+    echo "$ORIGINAL_CONFIG" > "$BASE_DIR/cfg/build/current_config_path.txt"
+fi
+
 
 # Make flight software configuration directory
-mkdir -p $BASE_DIR/cfg/build
+mkdir -p "$BASE_DIR/cfg/build"
 
 # Copy baseline configurations into build directory
-cp -r $BASE_DIR/cfg/InOut $BASE_DIR/cfg/build/
-cp -r $BASE_DIR/cfg/nos3_defs $BASE_DIR/cfg/build/
-cp -r $BASE_DIR/cfg/sims $BASE_DIR/cfg/build/
+cp -r "$BASE_DIR/cfg/InOut" "$BASE_DIR/cfg/build/"
+cp -r "$BASE_DIR/cfg/nos3_defs" "$BASE_DIR/cfg/build/"
+cp -r "$BASE_DIR/cfg/sims" "$BASE_DIR/cfg/build/"
 
-# Configure flight software
-python3 $SCRIPT_DIR/cfg/configure.py
+# Run the configuration Python script
+python3 "$SCRIPT_DIR/cfg/configure.py" "$CONFIG_FILE"

--- a/scripts/cfg/config.sh
+++ b/scripts/cfg/config.sh
@@ -8,6 +8,14 @@ source "$SCRIPT_DIR/../env.sh"
 ORIGINAL_CONFIG="$BASE_DIR/cfg/nos3-mission.xml"
 CONFIG_FILE="$ORIGINAL_CONFIG"
 
+# Make flight software configuration directory
+mkdir -p "$BASE_DIR/cfg/build"
+
+# Copy baseline configurations into build directory
+cp -r "$BASE_DIR/cfg/InOut" "$BASE_DIR/cfg/build/"
+cp -r "$BASE_DIR/cfg/nos3_defs" "$BASE_DIR/cfg/build/"
+cp -r "$BASE_DIR/cfg/sims" "$BASE_DIR/cfg/build/"
+
 # If SC1_CFG is passed in, validate and patch
 if [ -n "${SC1_CFG// }" ]; then
     REL_SC1_CFG="${SC1_CFG#cfg/}"   # Strip leading cfg/ if present
@@ -19,24 +27,14 @@ if [ -n "${SC1_CFG// }" ]; then
     fi
 
     echo "Overriding <sc-1-cfg> with: $REL_SC1_CFG"
-    TEMP_CONFIG=$(mktemp)
+    TEMP_CONFIG=$(mktemp "$BASE_DIR/cfg/XXXXXX.xml")
     sed "s|<sc-1-cfg>.*</sc-1-cfg>|<sc-1-cfg>$REL_SC1_CFG</sc-1-cfg>|" "$ORIGINAL_CONFIG" > "$TEMP_CONFIG"
     CONFIG_FILE="$TEMP_CONFIG"
 
     echo "$CONFIG_FILE" > "$BASE_DIR/cfg/build/current_config_path.txt"
 else
-    echo "NO CHANGES TO CONFIG"
     echo "$ORIGINAL_CONFIG" > "$BASE_DIR/cfg/build/current_config_path.txt"
 fi
-
-
-# Make flight software configuration directory
-mkdir -p "$BASE_DIR/cfg/build"
-
-# Copy baseline configurations into build directory
-cp -r "$BASE_DIR/cfg/InOut" "$BASE_DIR/cfg/build/"
-cp -r "$BASE_DIR/cfg/nos3_defs" "$BASE_DIR/cfg/build/"
-cp -r "$BASE_DIR/cfg/sims" "$BASE_DIR/cfg/build/"
 
 # Run the configuration Python script
 python3 "$SCRIPT_DIR/cfg/configure.py" "$CONFIG_FILE"

--- a/scripts/cfg/configure.py
+++ b/scripts/cfg/configure.py
@@ -10,7 +10,7 @@ import xml.etree.ElementTree as ET
 import sys
 
 # Use passed-in mission file if provided, otherwise default to ./cfg/nos3-mission.xml
-mission_file = sys.argv[1] if len(sys.argv) > 1 else './cfg/nos3-mission.xml'
+mission_file = sys.argv[1] if len(sys.argv) > 1 else 'nos3-mission.xml'
 
 # Ensure it exists
 if not os.path.isfile(mission_file):
@@ -18,7 +18,7 @@ if not os.path.isfile(mission_file):
     sys.exit(1)
 
 # Parse mission configuration
-mission_tree = ET.parse(mission_file)
+mission_tree = ET.parse("./cfg/" + os.path.basename(mission_file))
 mission_root = mission_tree.getroot()
 mission_start_time = mission_root.find('start-time').text
 print('  start-time:', mission_start_time)

--- a/scripts/cfg/configure.py
+++ b/scripts/cfg/configure.py
@@ -18,7 +18,7 @@ if not os.path.isfile(mission_file):
     sys.exit(1)
 
 # Parse mission configuration
-mission_tree = ET.parse("./cfg/" + os.path.basename(mission_file))
+mission_tree = ET.parse("./cfg/build/temp_mission/" + os.path.basename(mission_file))
 mission_root = mission_tree.getroot()
 mission_start_time = mission_root.find('start-time').text
 print('  start-time:', mission_start_time)

--- a/scripts/cfg/configure.py
+++ b/scripts/cfg/configure.py
@@ -7,15 +7,24 @@
 import datetime
 import os
 import xml.etree.ElementTree as ET
+import sys
+
+# Use passed-in mission file if provided, otherwise default to ./cfg/nos3-mission.xml
+mission_file = sys.argv[1] if len(sys.argv) > 1 else './cfg/nos3-mission.xml'
+
+# Ensure it exists
+if not os.path.isfile(mission_file):
+    print(f"ERROR: Mission configuration file '{mission_file}' not found!")
+    sys.exit(1)
 
 # Parse mission configuration
-mission_tree = ET.parse('./cfg/nos3-mission.xml')
+mission_tree = ET.parse(mission_file)
 mission_root = mission_tree.getroot()
 mission_start_time = mission_root.find('start-time').text
 print('  start-time:', mission_start_time)
 mission_start_time_utc = datetime.datetime(2000, 1, 1, 12, 0) + datetime.timedelta(seconds=float(mission_start_time))
 print('  start-time-utc:', mission_start_time_utc)
-
+print('  mission-file: ', mission_file)
 # FSW
 fsw_str = 'fsw'
 fsw_cfg = mission_root.find(fsw_str).text


### PR DESCRIPTION
### Changes:

These changes allow for users to pass a variable into the `make config` command.

eg.
`make config SC1_CFG=spacecraft/sc-minimal-config.xml`

This will create a temporary config file in the /tmp directory, as well as a file within the ./cfg/build directory named "current_config_path.txt" which contains the path to this temporary file.

This path will be passed into the python config file, and utilized within the launch script.

`make stop` will cleanup and remove this temporary configuration file.

**Note:**  The script currently assumes that we will be working from the ./cfg directory, so you can give the pathing for the config file starting with /spacecraft.

### To Test:
Modify two of your spacecraft configs to be visibly different upon launch (turn off 42 gui in one configuration, and on in another is a good test)
Start your config in the default sc-mission-config.xml (with 42 on).  Verify startup.
(You can use the default `make config` `make` `make launch` here)
Stop the simulation, and reconfigure to use the minimal config:

`make stop`
`make clean`
`make config SC1_CFG=spacecraft/sc-minimal-config.xml`
`make`
`make launch`

Verify that everything starts with the minimal config (42 GUI not launching in this option)
Verify that a current_config_path.txt is created during make config
Verify that `make stop` removes this configuration path file and temporary configuration file.

**No Changes to Submodules**

closes: #561 


