### PR TITLE
[nasa/nos3#591] Added scripts to configure cosmos targets

### DIFF
--- a/scripts/cfg/config.sh
+++ b/scripts/cfg/config.sh
@@ -39,3 +39,10 @@ fi
 
 # Run the configuration Python script
 python3 "$SCRIPT_DIR/cfg/configure.py" "$CONFIG_FILE"
+
+# Configure Cosmos Targets
+for i in $(find ./components/ -mindepth 1 -maxdepth 1 -type d)
+do
+    python3 $BASE_DIR/scripts/cfg/declare_cosmos_target.py $i
+    python3 $BASE_DIR/scripts/cfg/configure_cosmos_target.py $i
+done

--- a/scripts/cfg/config.sh
+++ b/scripts/cfg/config.sh
@@ -41,8 +41,5 @@ fi
 python3 "$SCRIPT_DIR/cfg/configure.py" "$CONFIG_FILE"
 
 # Configure Cosmos Targets
-for i in $(find ./components/ -mindepth 1 -maxdepth 1 -type d)
-do
-    python3 $BASE_DIR/scripts/cfg/declare_cosmos_target.py $i
-    python3 $BASE_DIR/scripts/cfg/configure_cosmos_target.py $i
-done
+python3 $BASE_DIR/scripts/cfg/declare_cosmos_target.py
+python3 $BASE_DIR/scripts/cfg/configure_cosmos_target.py $i

--- a/scripts/cfg/configure_cosmos_target.py
+++ b/scripts/cfg/configure_cosmos_target.py
@@ -1,0 +1,116 @@
+import sys
+import os
+import xml.etree.ElementTree as ET
+
+components = {
+    "arducam" : "cam",
+    "cryptolib" : "cryptolib",
+    "generic_adcs" : "adcs",
+    "generic_css" : "css",
+    "generic_eps" : "eps",
+    "generic_fss" : "fss",
+    "generic_imu" : "imu",
+    "generic_mag" : "mag",
+    "generic_radio" : "radio",
+    "generic_reaction_wheel" : "rw",
+    "generic_star_tracker" : "st",
+    "generic_thruster" : "thruster",
+    "generic_torquer" : "torquer",
+    "mgr" : "mgr",
+    "novatel_oem615" : "novatel_oem615",
+    "onair" : "onair",
+    "sample" : "sample",
+    "syn" : "syn"
+}
+
+def main():
+    mission_file = 'nos3-mission.xml'
+    mission_tree = ET.parse("./cfg/build/temp_mission/" + os.path.basename(mission_file))
+    mission_root = mission_tree.getroot()
+    sc_cfg = mission_root.find("sc-1-cfg").text
+    sc_cfg_str = './cfg/' + sc_cfg
+    sc_tree = ET.parse(sc_cfg_str)
+    sc_root = sc_tree.getroot()
+
+    component = sys.argv[1]
+    component = component.split('/')[-1]
+
+    xml_path = 'components/{x}/enable'.format(x=components[component])
+    component = component.upper()
+
+    # Parse spacecraft configuration
+    sc_component_en = None
+    try:
+        sc_component_en = sc_root.find(xml_path).text
+    except AttributeError:
+        pass
+
+    if type(sc_component_en) == None:
+        sys.exit()
+
+    write_lines = []
+    if sc_component_en == 'false':
+        # remove the target from COSMOS
+        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'r') as fp:
+            lines = fp.read().splitlines()
+            for line in lines:
+                if line in [
+                    f'  TARGET {component}',
+                    f'  TARGET GENERIC_{component}',
+                    f'  TARGET {component}_RADIO',
+                    f'  TARGET GENERIC_{component}_RADIO',
+                    f'  TARGET SYNOPSIS',
+                    f'  TARGET SYNOPSIS_RADIO'
+                ]:
+                    print("Removed:", line)
+                else:
+                    write_lines.append(line + "\n")
+            fp.close()
+    elif sc_component_en == 'true':
+        # add the target to cosmos
+        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'r') as fp:
+            line_found = False
+            radio_found = False
+            syn_found = False
+            syn_radio_found = False
+            interface = None
+            lines = fp.read().splitlines()
+            for line in lines:
+                if line.split(" ")[0] == "INTERFACE" and interface != None:
+                    # add lines if you reach the next interface
+                    if line_found == False:
+                        write_lines.append(f'  TARGET {component}\n')
+                    if radio_found == False:
+                        write_lines.append(f'TARGET {component}_RADIO\n')
+                    if component == "SYN" and syn_found == False:
+                        write_lines.append(f'  TARGET SYNOPSIS\n')
+                    if component == "SYN" and syn_radio_found == False:
+                        write_lines.append(f'  TARGET SYNOPSIS_RADIO\n')
+                    interface = line.split()[1]
+                elif line in [
+                    f'  TARGET {component}',
+                    f'  TARGET GENERIC_{component}',
+                ]:
+                    line_found = True
+                elif line in [
+                    f'  TARGET {component}_RADIO',
+                    f'  TARGET GENERIC_{component}_RADIO',
+                ]:
+                    radio_found = True
+                elif component == "SYN":
+                    if line == f'  TARGET SYNOPSIS':
+                        syn_found = True
+                    if line == f'  TARGET SYNOPSIS_RADIO':
+                        syn_radio_found = True
+                write_lines.append(line + "\n")
+            
+            fp.close()
+
+    if len(write_lines) > 0:
+        os.remove("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt")
+        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'a') as new_fp:
+            new_fp.writelines(write_lines)
+    
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cfg/configure_cosmos_target.py
+++ b/scripts/cfg/configure_cosmos_target.py
@@ -1,116 +1,86 @@
-import sys
 import os
+import shutil
 import xml.etree.ElementTree as ET
 
+# Component to XML mapping
 components = {
-    "arducam" : "cam",
-    "cryptolib" : "cryptolib",
-    "generic_adcs" : "adcs",
-    "generic_css" : "css",
-    "generic_eps" : "eps",
-    "generic_fss" : "fss",
-    "generic_imu" : "imu",
-    "generic_mag" : "mag",
-    "generic_radio" : "radio",
-    "generic_reaction_wheel" : "rw",
-    "generic_star_tracker" : "st",
-    "generic_thruster" : "thruster",
-    "generic_torquer" : "torquer",
-    "mgr" : "mgr",
-    "novatel_oem615" : "novatel_oem615",
-    "onair" : "onair",
-    "sample" : "sample",
-    "syn" : "syn"
+    "arducam": "cam",
+    "cryptolib": "radio",
+    "generic_adcs": "adcs",
+    "generic_css": "css",
+    "generic_eps": "eps",
+    "generic_fss": "fss",
+    "generic_imu": "imu",
+    "generic_mag": "mag",
+    "generic_radio": "radio",
+    "generic_reaction_wheel": "rw",
+    "generic_star_tracker": "st",
+    "generic_thruster": "thruster",
+    "generic_torquer": "torquer",
+    "mgr": "mgr",
+    "novatel_oem615": "gps",
+    "onair": "onair",
+    "sample": "sample",
+    "syn": "syn"
 }
 
+def clean_target_lines(input_file, output_file, sc_root):
+    """Remove TARGET lines for disabled components (and their _RADIO versions)."""
+    with open(input_file, 'r') as f:
+        lines = f.readlines()
+
+    lines_to_remove = set()
+
+    for comp_key, xml_name in components.items():
+        component_upper = comp_key.upper()
+        node = sc_root.find(f"components/{xml_name}/enable")
+        enabled = node is not None and node.text.strip().lower() == 'true'
+
+        if enabled:
+            continue
+
+        print(f"[REMOVE] {comp_key} disabled — removing TARGET lines.")
+        lines_to_remove.update({
+            f"TARGET {component_upper}",
+            f"TARGET {component_upper}_RADIO"
+        })
+
+        # Special case for 'syn' → SYNOPSIS
+        if comp_key == "syn":
+            lines_to_remove.update({
+                "TARGET SYNOPSIS",
+                "TARGET SYNOPSIS_RADIO"
+            })
+
+    # Filter out unwanted lines
+    filtered_lines = [line for line in lines if line.strip() not in lines_to_remove]
+
+    with open(output_file, 'w') as f:
+        f.writelines(filtered_lines)
+
 def main():
+    # === Parse XML to get SC config ===
     mission_file = 'nos3-mission.xml'
-    mission_tree = ET.parse("./cfg/build/temp_mission/" + os.path.basename(mission_file))
-    mission_root = mission_tree.getroot()
-    sc_cfg = mission_root.find("sc-1-cfg").text
-    sc_cfg_str = './cfg/' + sc_cfg
-    sc_tree = ET.parse(sc_cfg_str)
-    sc_root = sc_tree.getroot()
-
-    component = sys.argv[1]
-    component = component.split('/')[-1]
-
-    xml_path = 'components/{x}/enable'.format(x=components[component])
-    component = component.upper()
-
-    # Parse spacecraft configuration
-    sc_component_en = None
-    try:
-        sc_component_en = sc_root.find(xml_path).text
-    except AttributeError:
-        pass
-
-    if type(sc_component_en) == None:
-        sys.exit()
-
-    write_lines = []
-    if sc_component_en == 'false':
-        # remove the target from COSMOS
-        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'r') as fp:
-            lines = fp.read().splitlines()
-            for line in lines:
-                if line in [
-                    f'  TARGET {component}',
-                    f'  TARGET GENERIC_{component}',
-                    f'  TARGET {component}_RADIO',
-                    f'  TARGET GENERIC_{component}_RADIO',
-                    f'  TARGET SYNOPSIS',
-                    f'  TARGET SYNOPSIS_RADIO'
-                ]:
-                    print("Removed:", line)
-                else:
-                    write_lines.append(line + "\n")
-            fp.close()
-    elif sc_component_en == 'true':
-        # add the target to cosmos
-        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'r') as fp:
-            line_found = False
-            radio_found = False
-            syn_found = False
-            syn_radio_found = False
-            interface = None
-            lines = fp.read().splitlines()
-            for line in lines:
-                if line.split(" ")[0] == "INTERFACE" and interface != None:
-                    # add lines if you reach the next interface
-                    if line_found == False:
-                        write_lines.append(f'  TARGET {component}\n')
-                    if radio_found == False:
-                        write_lines.append(f'TARGET {component}_RADIO\n')
-                    if component == "SYN" and syn_found == False:
-                        write_lines.append(f'  TARGET SYNOPSIS\n')
-                    if component == "SYN" and syn_radio_found == False:
-                        write_lines.append(f'  TARGET SYNOPSIS_RADIO\n')
-                    interface = line.split()[1]
-                elif line in [
-                    f'  TARGET {component}',
-                    f'  TARGET GENERIC_{component}',
-                ]:
-                    line_found = True
-                elif line in [
-                    f'  TARGET {component}_RADIO',
-                    f'  TARGET GENERIC_{component}_RADIO',
-                ]:
-                    radio_found = True
-                elif component == "SYN":
-                    if line == f'  TARGET SYNOPSIS':
-                        syn_found = True
-                    if line == f'  TARGET SYNOPSIS_RADIO':
-                        syn_radio_found = True
-                write_lines.append(line + "\n")
-            
-            fp.close()
-
-    if len(write_lines) > 0:
-        os.remove("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt")
-        with open("./gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt", 'a') as new_fp:
-            new_fp.writelines(write_lines)
+    mission_path = "./cfg/build/temp_mission/" + os.path.basename(mission_file)
     
+    try:
+        mission_tree = ET.parse(mission_path)
+        mission_root = mission_tree.getroot()
+        sc_cfg = mission_root.find("sc-1-cfg").text
+        sc_cfg_path = './cfg/' + sc_cfg
+        sc_tree = ET.parse(sc_cfg_path)
+        sc_root = sc_tree.getroot()
+    except Exception as e:
+        print(f"Error parsing XML: {e}")
+        return
 
-if __name__ == "__main__":
+    # === File paths ===
+    input_path = './gsw/cosmos/config/tools/cmd_tlm_server/stash/cmd_tlm_server.txt'
+    output_path = './gsw/cosmos/config/tools/cmd_tlm_server/cmd_tlm_server.txt'
+
+    shutil.copyfile(input_path, output_path)
+
+    clean_target_lines(output_path, output_path, sc_root)
+
+if __name__ == '__main__':
     main()

--- a/scripts/cfg/declare_cosmos_target.py
+++ b/scripts/cfg/declare_cosmos_target.py
@@ -1,0 +1,101 @@
+import sys
+import os
+import xml.etree.ElementTree as ET
+
+components = {
+    "arducam" : "cam",
+    "cryptolib" : "cryptolib",
+    "generic_adcs" : "adcs",
+    "generic_css" : "css",
+    "generic_eps" : "eps",
+    "generic_fss" : "fss",
+    "generic_imu" : "imu",
+    "generic_mag" : "mag",
+    "generic_radio" : "radio",
+    "generic_reaction_wheel" : "rw",
+    "generic_star_tracker" : "st",
+    "generic_thruster" : "thruster",
+    "generic_torquer" : "torquer",
+    "mgr" : "mgr",
+    "novatel_oem615" : "novatel_oem615",
+    "onair" : "onair",
+    "sample" : "sample",
+    "syn" : "syn"
+}
+
+def main():
+    mission_file = 'nos3-mission.xml'
+    mission_tree = ET.parse("./cfg/build/temp_mission/" + os.path.basename(mission_file))
+    mission_root = mission_tree.getroot()
+    sc_cfg = mission_root.find("sc-1-cfg").text
+    sc_cfg_str = './cfg/' + sc_cfg
+    sc_tree = ET.parse(sc_cfg_str)
+    sc_root = sc_tree.getroot()
+
+    component = sys.argv[1]
+    component = component.split('/')[-1]
+
+    xml_path = 'components/{x}/enable'.format(x=components[component])
+    component = component.upper()
+
+    # Parse spacecraft configuration
+    sc_component_en = None
+    try:
+        sc_component_en = sc_root.find(xml_path).text
+    except AttributeError:
+        pass
+
+    write_lines = []
+    if sc_component_en == 'false':
+        # remove the target from COSMOS
+        with open("./gsw/cosmos/config/system/system.txt", 'r') as fp:
+            lines = fp.read().splitlines()
+            for line in lines:
+                if line in [
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} {component}',
+                    f'DECLARE_TARGET ../../COMPONENTS/GENERIC_{component} GENERIC_{component}',
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} {component}_RADIO',
+                    f'DECLARE_TARGET ../../COMPONENTS/GENERIC_{component} GENERIC_{component}_RADIO',
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} SYNOPSIS',
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} SYNOPSIS_RADIO'
+                ]:
+                    print("Removed:", line)
+                else:
+                    write_lines.append(line + "\n")
+            fp.close()
+    elif sc_component_en == 'true':
+        # add the target to cosmos
+        with open("./gsw/cosmos/config/system/system.txt", 'r') as fp:
+            line_found = False
+            radio_found = False
+            lines = fp.read().splitlines()
+            for line in lines:
+                if line in [
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} {component}',
+                    f'DECLARE_TARGET ../../COMPONENTS/GENERIC_{component} GENERIC_{component}',
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} SYNOPSIS',
+                ]:
+                    line_found = True
+                elif line in [
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} {component}_RADIO',
+                    f'DECLARE_TARGET ../../COMPONENTS/GENERIC_${component} GENERIC_{component}_RADIO',
+                    f'DECLARE_TARGET ../../COMPONENTS/{component} SYNOPSIS_RADIO'
+                ]:
+                    radio_found = True
+                write_lines.append(line + "\n")
+            if line_found == False:
+                write_lines.append(f'DECLARE_TARGET ../../COMPONENTS/{component} {component}\n')
+                print(f'Added: DECLARE_TARGET ../../COMPONENTS/{component} {component}\n')
+            if radio_found == False:
+                write_lines.append(f'DECLARE_TARGET ../../COMPONENTS/{component} {component}_RADIO\n')
+                print(f'Added: DECLARE_TARGET ../../COMPONENTS/{component} {component}_RADIO\n')
+            fp.close()
+
+    if len(write_lines) > 0:
+        os.remove("./gsw/cosmos/config/system/system.txt")
+        with open("./gsw/cosmos/config/system/system.txt", 'a') as new_fp:
+            new_fp.writelines(write_lines)
+    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added to the end of `make config`. The scripts read the xml file, then adds/removes based on the enable status.

Requires:
- https://github.com/nasa-itc/gsw-cosmos/pull/31