### PR TITLE
[nasa/nos3#644] Configure time in nos3-mission.xml

### DIFF
--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -1,4 +1,6 @@
 <nos3-mission-cfg>
+    <!-- Mission Start Time (J2000 UTC) -->
+    <!-- Default time: 814254200.0, 20 Oct 2025 -->
     <start-time>814254200.0</start-time>
 
     <!-- Ground Software -->

--- a/scripts/cfg/configure.py
+++ b/scripts/cfg/configure.py
@@ -436,6 +436,8 @@ else:
         with open('./cfg/build/sims/nos3-simulator.xml', 'r') as fp:
             lines = fp.readlines()
             for line in lines:
+                if line.find('<absolute-start-time>') != -1:
+                    lines[lines.index(line)] = "        <absolute-start-time>{}</absolute-start-time>\n".format(mission_start_time)
                 if line.find('camsim</name>') != -1:
                     if (lines.index(line)) < cam_index:
                         cam_index = lines.index(line) + 1


### PR DESCRIPTION
…tart time based on nos3-mission.xml start time.

To test:
- Set time in `cfg/nos3-mission.xml`
- Run `make config`
- Verify times in `cfg/build/sims/nos3-simulator.xml` and `cfg/build/InOut/Inp_Sim.txt` get set appropriately (to convert, use https://nsidc.org/data/icesat/glas-date-conversion-tool/date_convert/).

Closes #644 