### PR TITLE
[nasa/nos3#643] Update to container with updated build of NOS Engine

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -48,7 +48,7 @@ INFLUXDB_ADMIN_PASSWORD=admin_password
     DNETWORK="docker network"
 #fi
 
-DBOX="ivvitc/nos3-64:20250217"
+DBOX="ivvitc/nos3-64:20250514"
 
 # Debugging
 #echo "Script directory = " $SCRIPT_DIR


### PR DESCRIPTION
Simply updates the docker container for use to the newer one where NOS Engine was updated with a version that has additional warning messages suppressed. 

How to test?
* git checkout nos3#643-engine-error
* make uninstall
* make prep
* make
* make launch
* Manually confirm that when enable/disable sample the extra engine errors in FSW are no longer shown
* Manually confirm everything still broadly works

Submodule PRs and actions prior to closing this:
* https://github.com/nasa-itc/deployment/pull/20

Closes #643.



