### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NASA Operational Simulator for Space Systems (NOS3)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nasa/nos3)
 
 NOS3 is a suite of tools developed by NASA's Katherine Johnson Independent Verification and Validation (IV&V) Facility to aid in areas such as software development, integration & test (I&T), mission operations/training, verification and validation (V&V), and software systems check-out. 
 NOS3 provides a software development environment, a multi-target build system, an operator interface/ground station, dynamics and environment simulations, and software-based models of spacecraft hardware.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/nasa/nos3) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.