### PR TITLE
Nos3#811 fprime startup sequence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-cryptolib: ## Build CryptoLib Component, ## -DSTANDALONE_TCP=0 if using ud
 
 build-fsw: ## Build the flight software (cFS or F')
 ifeq ($(FLIGHT_SOFTWARE), fprime)
-	cd fsw/fprime/fprime-nos3 && fprime-util generate && fprime-util build
+	cd fsw/fprime/fprime-nos3 && fprime-util generate && fprime-util build && fprime-seqgen Sequences/nos3test.seq -d build-artifacts/Linux/deployment/dict/deploymentTopologyDictionary.json
 else
 	mkdir -p $(FSWBUILDDIR)
 	cd $(FSWBUILDDIR) && cmake $(PREP_OPTS) ../cfe
@@ -128,6 +128,7 @@ clean-fsw: ## Clean only flight software build artifacts
 	rm -rf fsw/fprime/fprime-nos3/build-fprime-automatic-native
 	rm -rf fsw/fprime/fprime-nos3/fprime-venv
 	rm -rf fsw/fprime/fprime-nos3/logs
+	rm -f fsw/fprime/fprime-nos3/Sequences/*.bin
 
 clean-sim: ## Clean only simulator build artifacts
 	rm -rf sims/build

--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -5,11 +5,11 @@
 
     <!-- Ground Software -->
     <!-- cosmos (default), openc3, fprime, or yamcs -->
-    <gsw>fprime</gsw>
+    <gsw>cosmos</gsw>
 
     <!-- Flight Software -->
     <!-- cfs (default) or fprime -->
-    <fsw>fprime</fsw>
+    <fsw>cfs</fsw>
 
     <!-- Scenario -->
     <!-- STF1 (default) or Gateway -->
@@ -24,7 +24,7 @@
     <!-- sc-mission-config.xml (default, minimal + generic components and ADCS) -->
     <!-- sc-research-config.xml (mission + research integrations, arducam, and generic-thruster) -->
     <!-- sc-fprime-config.xml (only configuration supporting F') -->
-    <sc-1-cfg>spacecraft/sc-fprime-config.xml</sc-1-cfg>
+    <sc-1-cfg>spacecraft/sc-mission-config.xml</sc-1-cfg>
 
     <!-- Spacecraft N Configuration -->
     <!-- <sc-N-cfg>sc-minimal-config.xml</sc-N-cfg> -->

--- a/cfg/nos3-mission.xml
+++ b/cfg/nos3-mission.xml
@@ -5,11 +5,11 @@
 
     <!-- Ground Software -->
     <!-- cosmos (default), openc3, fprime, or yamcs -->
-    <gsw>cosmos</gsw>
+    <gsw>fprime</gsw>
 
     <!-- Flight Software -->
     <!-- cfs (default) or fprime -->
-    <fsw>cfs</fsw>
+    <fsw>fprime</fsw>
 
     <!-- Scenario -->
     <!-- STF1 (default) or Gateway -->
@@ -24,7 +24,7 @@
     <!-- sc-mission-config.xml (default, minimal + generic components and ADCS) -->
     <!-- sc-research-config.xml (mission + research integrations, arducam, and generic-thruster) -->
     <!-- sc-fprime-config.xml (only configuration supporting F') -->
-    <sc-1-cfg>spacecraft/sc-mission-config.xml</sc-1-cfg>
+    <sc-1-cfg>spacecraft/sc-fprime-config.xml</sc-1-cfg>
 
     <!-- Spacecraft N Configuration -->
     <!-- <sc-N-cfg>sc-minimal-config.xml</sc-N-cfg> -->

--- a/docs/wiki/NOS3_Flight_Software.md
+++ b/docs/wiki/NOS3_Flight_Software.md
@@ -342,6 +342,27 @@ TB\_Dont\_Care enum to overwrite time in F-Prime, but this adds a slight
 delay at the beginning of time synchronization between nos engine and
 F-Prime.
 
+### F-Prime Sequencing
+Creating sequences in Fprime can be done using the following steps:
+
+1. Use the `Sequences` Tab in the Fprime GDS to construct your preferred sequence. Name it accordingly with a .seq file extension and download it using `Save As`.
+
+2. Put the sequence file in the `fsw/fprime/fprime-nos3/Sequences/` folder
+
+3. Enter debug mode (`make debug`) and navigate to `fsw/fprime/fprime-nos3`. Compile the sequence into a .bin file using the below command.
+
+```
+fprime-seqgen Sequences/[filename].seq -d build-artifacts/Linux/deployment/dict/deploymentTopologyDictionary.json
+```
+
+Running sequences can be done through a variety of ways:
+
+* In Fprime GDS, use the CS_RUN command with the file parameter being `Sequences/___.bin` and the preferred blocking option. 
+
+* For startup scripts, modify the docker exec command at the end of `scripts/fsw/fsw_fprime_launch.sh` to run your specific `sequence.bin` file. Alterations can be made in the Makefile's `build-fsw` for sequence compilation.
+
+* The `fprime-cli` command has the ability to manually run sequences through the `CS_RUN` command similar to how the startup sequence works.
+
 ### F-Prime Documentation links:
 
 * F-Prime github Docs: [https://nasa.github.io/fprime/](https://nasa.github.io/fprime/)

--- a/scripts/fsw/fsw_fprime_launch.sh
+++ b/scripts/fsw/fsw_fprime_launch.sh
@@ -165,4 +165,6 @@ then
     firefox ${urlIP}:5000 & 
 fi
 
+docker exec sc01-fprime sh -c "sleep 15 && cd fsw/fprime/fprime-nos3 && fprime-cli command-send deployment.cmdSeq.CS_RUN --arguments Sequences/nos3test.bin NO_BLOCK"
+
 echo "Docker launch script completed!"


### PR DESCRIPTION
Fprime Sequencing and Startup Sequencing
Full cFS-like sequencing will come after Fprime 4.0 issues with SPI and Rate Group 4 are fixed.

How to test?

Run fprime configuration of NOS3
Once everything launches, check Events tab in Fprime GDS and make sure nos3test sequence is running .
[Optional] Follow directions in Flight Software Docs (specifically F-Prime Sequencing) to make and run a custom sequence (manually or at startup, either or)
Submodule PRs and actions prior to closing this:
[fprime-nos3](https://github.com/nasa-itc/fprime-nos3/pull/30)

Closes #811 