### PR TITLE
Fix #874, remove stale environment source from prepare.sh

### DIFF
--- a/scripts/cfg/prepare.sh
+++ b/scripts/cfg/prepare.sh
@@ -5,9 +5,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/../env.sh
 
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source $SCRIPT_DIR/env.sh
 echo ""
 echo ""
 


### PR DESCRIPTION
Fix #874.

Remove the duplicate environment source left behind when `prepare.sh` moved from `scripts/` to `scripts/cfg/`. The script already loads `scripts/env.sh` through `../env.sh`; the stale second source tries to load the nonexistent `scripts/cfg/env.sh`.

Expected behavior:

`make prep` no longer reports:

```text
bash: /home/haozhou/work/nos3/scripts/cfg/env.sh: No such file or directory
```

All other preparation behavior remains unchanged.

How to test?

* Run `bash -n scripts/cfg/prepare.sh`.
* Load `scripts/env.sh` through the relative path used by the preparation script and verify `BASE_DIR`, `DCALL`, `DBOX`, and `USER_NOS3_DIR` are populated.
* Run `git diff --check origin/dev...HEAD`.

Submodule PRs and actions prior to closing this:

* None.

Observed on Ubuntu 24.04.4 LTS (x86_64) with Bash 5.2.21.

Contributor: @haozhou-wong